### PR TITLE
use index of enumerate for question id

### DIFF
--- a/routes/api/make/validateQuizData.py
+++ b/routes/api/make/validateQuizData.py
@@ -16,10 +16,10 @@ def validateQuizData(data) -> tuple[bool, list[Question]]:
                 return False, []
 
             newData: list[Question] = []
-            for question in data:  # TODO use index of enumerate for question id
+            for index,question in enumerate(data):
                 newData.append(
                     Question(
-                        id=question.get("id"),
+                        id=index+1, # enumerate starts at 0
                         correctOption=question.get("correctOption"),
                         title=question.get("title"),
                         options={


### PR DESCRIPTION
In validateQuizData.py the id of the question was set by the id sent by the client;
this is risky as the id sent by the user can be wrong
hence the index should be generated at the backend